### PR TITLE
throttle pair aggregation

### DIFF
--- a/ticker.py
+++ b/ticker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from time import time
+from time import time, sleep
 import json
 import toml
 import argparse
@@ -75,6 +75,7 @@ def aggregate_pair(horizon_host, pair, start, end, resolution):
     params = make_aggregation_params(pair, start, end, resolution)
     url = horizon_host + "/trade_aggregations?" + urlencode(params)
     consumed = False
+    sleep(1)
     while not consumed:
         print "fetching url:", url
         json_result = get_json(url)


### PR DESCRIPTION
 * aggregates only 1 currency pair per second, using time.sleep()
 * prevents horizon.stellar.org rate limiting